### PR TITLE
Fix immediate synchronization

### DIFF
--- a/service_handler.go
+++ b/service_handler.go
@@ -220,7 +220,7 @@ func (s *AddressBook) DeleteService(rawurl string) {
 		service.Stop()
 		delete(s.entries, rawurl)
 	} else {
-		log.Print("no such entry to delete", rawurl)
+		log.Print("no such entry to delete: ", rawurl)
 	}
 	s.Mutex.Unlock()
 	s.statusServer.Delete(rawurl)
@@ -235,18 +235,18 @@ func (s *AddressBook) StartTickers() {
 			continue
 		}
 
-		log.Print(service.URL, " is not started, starting.")
+		service.running = true
 
 		go func(service *Service, status *StatusServer) {
 			if service.offset > 0 {
-				time.Sleep(time.Duration(service.offset) * time.Second)
+				waitSeconds := time.Duration(service.offset) * time.Second
+				time.Sleep(waitSeconds)
 			}
 
-			if !service.running && service.immediate {
+			if service.immediate {
 				// Force first tick if service is immediate
 				workerQuery(s, service, status)
 			}
-			service.running = true
 
 			for {
 				select {


### PR DESCRIPTION
Slipped a little, and missed a case where a service could be started
twice. This is because service.running was set inside the go func
closure, which could run whenever. It's better to place it outside and
block synchronization on setting this variable, before doing all the
fancy stuff.