### PR TITLE
Set makeResponse content-type to application/json

### DIFF
--- a/status.go
+++ b/status.go
@@ -162,6 +162,8 @@ func (s *StatusCache) makeResponse(w http.ResponseWriter, req *http.Request) {
 
 	jsonBuff, err := s.statusCacheToJSON(query)
 
+	w.Header().Set("Content-Type", "application/json")
+
 	var ret string
 	if err != nil {
 		log.Println("problem generating json for status endpoint: ", err)


### PR DESCRIPTION
Some of the existing example code starts a server that prints JSON at the `/status` endpoint, albeit with a content-type of `text/plain`:

```
> GET /status/ HTTP/1.1
> Host: 127.1:9999
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Thu, 28 Feb 2019 21:23:46 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
<
{}
```

Not using the proper Mime type is deleterious to thorough tools; those will refuse handling JSON text that is not presented as such.

With the code updated:

```
> GET /status/ HTTP/1.1
> Host: 127.1:9999
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Thu, 28 Feb 2019 21:23:59 GMT
< Content-Length: 2
<
{}
```

It is far from impossible that I made the trivial change in the wrong spot. Or other n00b mistakes. Please apply vague caution when reviewing.