### PR TITLE
Use make instead of find to build examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Taken from github.com/RAttab/gonfork
 all: build verify test examples
+
+EXAMPLES_GO := $(wildcard examples/*.go)
+EXAMPLES := $(patsubst %.go,%,$(EXAMPLES_GO))
+
 verify: vet lint
 test: test-cover test-race test-unused test-bench
 .PHONY: all verify test
@@ -54,10 +58,15 @@ test-bench:
 	go test -v -bench=.
 .PHONY: test-bench
 
-examples:
+examples_echo:
 	@echo -- building examples
-	@cd examples && find *.go -exec go build {} \;
-.PHONY: examples
+examples: examples_echo $(EXAMPLES)
+
+.PHONY: examples examples_echo
+
+%: %.go
+	@echo -- build $<
+	@go build -o $@ $<
 
 # https://github.com/dominikh/go-tools#tools
 test-unused:


### PR DESCRIPTION
Previously, the `examples` rule would run `find -exec go build` to
build examples. This had the following drawbacks:

1. A failure to build would not be reported by make, as find does not
   report `-exec` errors in its exit status;

2. examples could not be built in parallel.

With this change, `make -j` will build examples in parallel, and any
failures will be reported.

Example output:

```
$ make -j4 examples && echo OK
-- building examples
-- build examples/alert.go
-- build examples/every_ten_sec.go
-- build examples/imm_ten_sec.go
-- build examples/snapshot.go
-- build examples/status_cache.go
-- build examples/ten_sec.go
OK
```

Or when one of the programs is broken:

```
$ make -j4 examples && echo OK
-- building examples
-- build examples/alert.go
-- build examples/every_ten_sec.go
-- build examples/imm_ten_sec.go
-- build examples/snapshot.go
# command-line-arguments
examples/snapshot.go:30:27: syntax error: unexpected Zag at end of statement
make: *** [examples/snapshot] Error 2
make: *** Waiting for unfinished jobs....
```
